### PR TITLE
Make clear action public

### DIFF
--- a/Sources/Views/Pin/PinView.swift
+++ b/Sources/Views/Pin/PinView.swift
@@ -128,7 +128,7 @@ open class PinView: UIView {
         buttonZero.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
         
         // C
-        let buttonC = prepareButton(text: "C", type: .clear, action: #selector(PinView.clear(sender:)))
+        let buttonC = prepareButton(text: "C", type: .clear, action: #selector(PinView.clear))
         buttonC.topAnchor.constraint(equalTo: buttonZero.topAnchor).isActive = true
         buttonC.rightAnchor.constraint(equalTo: buttonZero.leftAnchor, constant: -buttonPadding).isActive = true
         buttonC.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor).isActive = true
@@ -170,7 +170,7 @@ open class PinView: UIView {
         }
     }
     
-    func clear(sender: PinButton) {
+    public func clear() {
         code.removeAll()
         reloadDotView()
     }


### PR DESCRIPTION
Het leek ons logisch dat de clear action ook publiek beschikbaar zou zijn. Voor cashfree, zouden we de mogelijkheid moeten hebben om na de completion van de pin, de controller te resetten zodat we een confirm pin actie kunnen doen.