### PR TITLE
Fixed iOS 11 issue with keyboardConstraint

### DIFF
--- a/Sources/Animations/KeyboardConstraint.swift
+++ b/Sources/Animations/KeyboardConstraint.swift
@@ -21,7 +21,7 @@ open class KeyboardConstraint: NSLayoutConstraint {
                                                queue: OperationQueue.main)
                     { [weak self] (notification) in
                         let userInfo = notification.userInfo
-                        let frameInfo = userInfo?[UIKeyboardFrameBeginUserInfoKey]
+                        let frameInfo = userInfo?[UIKeyboardFrameEndUserInfoKey]
                         if let keyboardSize = (frameInfo as? NSValue)?.cgRectValue {
                             let offset = self?.aboveKeyboard != nil ? self!.aboveKeyboard : 0
                             self?.animate(to: (keyboardSize.height + offset), userInfo: userInfo)


### PR DESCRIPTION
Keyboard height was sometimes 0 when animating.
Changed the notification userInfoKey for showing keyboard. 

Apple docs info: 

UIKeyboardFrameBeginUserInfoKey- The key for an NSValue object containing a CGRect that identifies the start frame of the keyboard in screen coordinates.

UIKeyboardFrameEndUserInfoKey - The key for an NSValue object containing a CGRect that identifies the end frame of the keyboard in screen coordinates.